### PR TITLE
Add JSON RCP support, Improve Readability and Allow Option Canceling

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -17,15 +17,13 @@
       var answer = JSON.parse(recv);
       if (answer.id == 1) {
          server = answer.result;
-      } else {
-        // console.log(answer.method);
-        if (Array.isArray(answer)) {
-          for (let i = 0; i < answer.length; i++) {
-            action(answer[i]);
-          }
-        } else {
-          action(answer);
+      } else if (Array.isArray(answer)) {
+        for (let i = 0; i < answer.length; i++) {
+          action(answer[i]);
         }
+      } else {
+        action(answer);
+      
       }
 
       show()

--- a/interface.html
+++ b/interface.html
@@ -1,589 +1,584 @@
 <html>
 
-    <head>
-        <title>Snapcast Interface</title>
-<script>
-
-//var connection = new WebSocket('ws://roomberryblue.fritz.box:2027', 'binary');
-var connection = new WebSocket('ws://'+window.location.hostname+':2027', 'binary');
-
-connection.binaryType = 'arraybuffer';
-
-var server;
-
-connection.onmessage = function (e) {
- var recv=String.fromCharCode.apply(null, new Uint8Array(e.data));
- // console.log(recv); 
-  var answer =JSON.parse(recv);
-  if(answer.id==1)
-   {server=answer.result;}
-  // console.log(answer.method);
-  if(answer.method=="Client.OnVolumeChanged" || answer.method=="Client.OnLatencyChanged" || answer.method=="Client.OnNameChanged")
-   {clientChange(answer.params);}
-  if(answer.method=="Client.OnConnect" || answer.method=="Client.OnDisconnect")
-   {clientConnect(answer.params);}
-  if(answer.method=="Group.OnMute")
-   {groupMute(answer.params);} 
-  if(answer.method=="Group.OnStreamChanged")
-   {groupStream(answer.params);} 
-  if(answer.method=="Stream.OnUpdate")
-   {streamUpdate(answer.params);}    
-  if(answer.method=="Server.OnUpdate")
-   {server=answer.params}
-   
-show()}
-
-connection.onopen = function() {
-send('{"id":1,"jsonrpc":"2.0","method":"Server.GetStatus"}}\n')
-}
-
-connection.onerror = function() {
-    alert("error");
-  }
-
-function send(str)
-{
-  var buf = new ArrayBuffer(str.length); 
-  var bufView = new Uint8Array(buf);
-  for (var i=0, strLen=str.length; i < strLen; i++) {
-    bufView[i] = str.charCodeAt(i);
-  }
-
-  //  console.log(buf);
- var recv=String.fromCharCode.apply(null, new Uint8Array(buf));
-//  console.log(recv); 
-  
-  connection.send(buf)
-  
-}  
-
-function clientChange(params)
-{//console.log(params);
-var i_group=0
-while(i_group<server.server.groups.length)
- {var i_client=0
- while(i_client<server.server.groups[i_group].clients.length)
-  {if(server.server.groups[i_group].clients[i_client].id==params.id)
-   {//console.log(server.server.groups[i_group].clients[i_client]);
-   server.server.groups[i_group].clients[i_client].config=Object.assign(server.server.groups[i_group].clients[i_client].config,params);
-   //console.log(server.server.groups[i_group].clients[i_client]); 
-   }
-  i_client++}
- i_group++}
-}
-
-function clientConnect(params)
-{//console.log(params);
-var i_group=0
-
-while(i_group<server.server.groups.length)
- {var i_client=0
-while(i_client<server.server.groups[i_group].clients.length)
-  {if(server.server.groups[i_group].clients[i_client].id==params.client.id)
-   {server.server.groups[i_group].clients[i_client]=params.client;
- //  console.log(server.server.groups[i_group].clients[i_client]); 
- }
-  i_client++}
- i_group++}
-}
-
-function groupMute(params)
-{//console.log(params);
-var i_group=0
-
-while(i_group<server.server.groups.length)
- {if(server.server.groups[i_group].id==params.id)
-   {server.server.groups[i_group].muted=params.mute;
-  // console.log(server.server.groups[i_group]); 
-  }
- i_group++}
-}
-
-function groupStream(params)
-{//console.log(params);
-var i_group=0
-
-while(i_group<server.server.groups.length)
- {if(server.server.groups[i_group].id==params.id)
-   {server.server.groups[i_group].stream_id=params.stream_id;
- //  console.log(server.server.groups[i_group]); 
- }
- i_group++}
-}
-
-function streamUpdate(params)
-{//console.log(params);
-var i_stream=0
-
-while(i_stream<server.server.streams.length)
- {if(server.server.streams[i_stream].id==params.id)
-   {server.server.streams[i_stream]=params.stream;
- //  console.log(server.server.streams[i_stream]); 
- }
- i_stream++}
-}
-
-function show()
-{
- var i_group=0;
-var content="";
-
-while(i_group<server.server.groups.length)
- {var i_client=0;
- var unmuted;
- var streamselect="<select id='stream_"+server.server.groups[i_group].id+"' onchange='setStream(\""+server.server.groups[i_group].id+"\")' class='stream'>"
- 
- var i_stream=0;
- while(i_stream<server.server.streams.length)
- {var streamselected="";
- if (server.server.groups[i_group].stream_id==server.server.streams[i_stream].id) {streamselected='selected'}
-streamselect=streamselect+"<option value='"+server.server.streams[i_stream].id+"' "+streamselected+">"+server.server.streams[i_stream].id+": "+server.server.streams[i_stream].status+"</option>";
- i_stream++}
- streamselect=streamselect+"</select>"; 
- var classgroup='group';
- if (server.server.groups[i_group].muted==true)
- {classgroup='groupmuted'}
-content=content+"<div id='g_"+server.server.groups[i_group].id+"' class='"+classgroup+"'>";
-content=content+streamselect;
-
-var mutetext;
-
-if (server.server.groups[i_group].muted==true) {unmuted='false';
-mutetext='&#x1F507';}
-if (server.server.groups[i_group].muted==false) {unmuted='true';
-mutetext='&#128266';}
-
-content=content+" <a href=\"javascript:setMuteGroup('"+server.server.groups[i_group].id+"','"+unmuted+"');\" class='mutebuttongroup'>"+mutetext+"</a>";
-//content=content+": "+server.server.groups[i_group].muted;
-
-content=content+"<input type='button' value='Refresh' class='refreshbutton' onclick='javascript: location.reload()'>";
-
-content=content+"<br>";
- while(i_client<server.server.groups[i_group].clients.length)
-  { 
-  var sv=server.server.groups[i_group].clients[i_client];
-  
-  var groupselect="<select id='group_"+sv.id+"' onchange='setGroup(\""+sv.id+"\")'>";
-  
-  var o_group=0
-  while(o_group<server.server.groups.length)
-  {var groupselected="";
-   if (o_group==i_group) {groupselected='selected'}
-  
-  groupselect=groupselect+"<option value='"+server.server.groups[o_group].id+"' "+groupselected+">Group "+o_group+" ("+server.server.groups[o_group].clients.length+" Clients)</option>";
- o_group++
-  }
-  groupselect=groupselect+"<option value='new'>new</option>";
-  groupselect=groupselect+"</select>"
-  
-   var name;
-   var unmuted;
-   if(sv.config.name!="") 
-	{name=sv.config.name;}
-else
-{name=sv.host.name;}	
-
-var clas='client'
-if(sv.connected==false) {clas='disconnected';}
-
-  content=content+"<div id='c_"+sv.id+"' class='"+clas+"'>";
-  
-  
-  var mutetextclient;
-  
-if (sv.config.volume.muted==true) {unmuted='false';
-  mutetext='&#128263';}
-if (sv.config.volume.muted==false) {unmuted='true';
-  mutetext='&#128266';}
-  content=content+" <a href=\"javascript:setVolume('"+sv.id+"','"+unmuted+"');\" class='mutebutton'>"+mutetext+"</a>";
-//  content=content+": "+sv.config.volume.muted;
-  
-  var sliderclass='slider';
-  if (sv.config.volume.muted==true)
-  {sliderclass='slidermute';}
-  
-  content=content+"<div class='sliders'><div class='sliderdiv'><input type='range' min=0 max=100 step=1 id='vol_"+sv.id+"' onchange='javascript:setVolume(\""+sv.id+"\",\""+sv.config.volume.muted+"\")' value="+sv.config.volume.percent+" class='"+sliderclass+"' orient='vertical'></div>";
-   content=content+"<div class='finebg'>++<br>+<br>0<br>-<br>--</div><div class='sliderdiv_fine'><input type='range' min=0 max=10 step=1 id='vol_fine_"+sv.id+"' onchange='javascript:setVolume(\""+sv.id+"\",\""+sv.config.volume.muted+"\")' value=5 class='"+sliderclass+"_fine' orient='vertical'></div></div>";
-  
-  content=content+" <a href=\"javascript:setName('"+sv.id+"');\" class='edit'>&#9998</a>";
-  content=content+name;
-//  content=content+" Connected:"+sv.connected;
-  content=content+groupselect;
-  content=content+"</div>";
-  
-  i_client++}
-  content=content+"</div>"
- i_group++}
- 
- content=content+"<br><br>";
- 
-
- 
- document.getElementById('show').innerHTML=content;
- 
-}
-
-function setVolume(id,mute)
-{
-
-percent=document.getElementById('vol_'+id).value;
-percent_fine=document.getElementById('vol_fine_'+id).value;
-
-//alert(percent +"  "+percent_fine+"  "+Number(percent));
-percent=Number(percent)+Number(percent_fine)-5;
-if(percent<0) {percent=0}
-if(percent>100) {percent=100}
-
-send('{"id":8,"jsonrpc":"2.0","method":"Client.SetVolume","params":{"id":"'+id+'","volume":{"muted":'+mute+',"percent":'+percent+'}}}}\n')
-
-var i_group=0
-
-while(i_group<server.server.groups.length)
- {var i_client=0
- while(i_client<server.server.groups[i_group].clients.length)
-  {var sv=server.server.groups[i_group].clients[i_client];
-  
- if(sv.id==id)
-   {if (mute=='true'){sv.config.volume.muted=true;}
-   if (mute=='false'){sv.config.volume.muted=false;}
-   sv.config.volume.percent=percent;
- //  console.log(server.server.groups[i_group]); 
- }
-   
-   i_client++}
-   
- i_group++}
- 
- 
-show()
-}
-
-
-
-
-function setMuteGroup(id,what)
-{
-
-send('{"id":"MuteGroup_'+id+'","jsonrpc":"2.0","method":"Group.SetMute","params":{"id":"'+id+'","mute":'+what+'}}}\n')
-
-var i_group=0
-
-while(i_group<server.server.groups.length)
- {if(server.server.groups[i_group].id==id)
-   {if (what=='true'){server.server.groups[i_group].muted=true;}
-   if (what=='false'){server.server.groups[i_group].muted=false;}
- //  console.log(server.server.groups[i_group]); 
- }
- i_group++}
-show()
-}
-
-function setStream(id)
-{
-
-send('{"id":4,"jsonrpc":"2.0","method":"Group.SetStream","params":{"id":"'+id+'","stream_id":"'+document.getElementById('stream_'+id).value+'"}}}\n')
-
-var i_group=0
-
-while(i_group<server.server.groups.length)
- {if(server.server.groups[i_group].id==id)
-   {
-   server.server.groups[i_group].stream_id=document.getElementById('stream_'+id).value;
- //  console.log(server.server.groups[i_group]); 
- }
- i_group++}
-show()
-}
-
-function setGroup(id)
-{group=document.getElementById('group_'+id).value;
-var current_group;
-var i_group=0
-
-while(i_group<server.server.groups.length)
- {
-   var i_client=0
-   while(i_client<server.server.groups[i_group].clients.length)
-   {if (id==server.server.groups[i_group].clients[i_client].id)
-    {current_group=server.server.groups[i_group].id}
-   i_client++}
- i_group++}
-
-
-var send_clients=[];
-
-var i_group=0
-
-while(i_group<server.server.groups.length)
- {if (server.server.groups[i_group].id==group || (group=="new" && server.server.groups[i_group].id==current_group))
-   {var i_client=0
-   while(i_client<server.server.groups[i_group].clients.length)
-   {if (group=="new" && server.server.groups[i_group].clients[i_client].id==id) {}
-   else
-   {//console.log(group);
-   //console.log(server.server.groups[i_group].clients[i_client].id);
-   //console.log(id);
-   send_clients[send_clients.length]=server.server.groups[i_group].clients[i_client].id;} 
-   i_client++}
-   }
- i_group++}
- if (group!="new")
- {send_clients[send_clients.length]=id;}
-
-var send_clients_string=JSON.stringify(send_clients);
-// console.log(send_clients_string);
- 
- var sendgroup=group
- if (group=="new") {group=current_group}
- 
- send('{"id":1,"jsonrpc":"2.0","method":"Group.SetClients","params":{"clients":'+send_clients_string+',"id":"'+group+'"}}}\n')
-//send('{"id":1,"jsonrpc":"2.0","method":"Server.GetStatus"}}\n')
-}
-
-function setName(id)
-{var current_name;
-var current_latemcy;
-var i_group=0;
-
-while(i_group<server.server.groups.length)
- {var i_client=0
- while(i_client<server.server.groups[i_group].clients.length)
-  {var sv=server.server.groups[i_group].clients[i_client];
-  
- if(sv.id==id)
-   {
-   if(sv.config.name!="") 
-	{current_name=sv.config.name;}
-else
-{current_name=sv.host.name;}	
-   current_latency=sv.config.latency;
-   }
-   
-   
-   i_client++}
-   
- i_group++}
-
-var newName=window.prompt("New Name",current_name);
-var newLatency=window.prompt("New Latency",current_latency);
-
-send('{"id":6,"jsonrpc":"2.0","method":"Client.SetName","params":{"id":"'+id+'","name":"'+newName+'"}}}\n')
-send('{"id":7,"jsonrpc":"2.0","method":"Client.SetLatency","params":{"id":"'+id+'","latency":'+newLatency+'}}}\n')
-
-var i_group=0;
-
-while(i_group<server.server.groups.length)
- {var i_client=0
- while(i_client<server.server.groups[i_group].clients.length)
-  {var sv=server.server.groups[i_group].clients[i_client];
-  
- if(sv.id==id)
-   {
-sv.config.name=newName;
-   sv.config.latency=newLatency;
-   }
-   
-   
-   i_client++}
-   
- i_group++}
- 
- show()
-
-}
-
-
-</script>
-
-<style>
-body {
-   background:#1f1f1f;
-   color:rgb(255, 255, 255);
-font-family: 'Arial', sans-serif;
-width: 100%;
-margin: 0;
-font-size: 20px;
-
-
-}
-
- /* width */
-::-webkit-scrollbar {
-    width: 10px;
-}
-
-/* Track */
-::-webkit-scrollbar-track {
-    background: #1f1f1f;
-}
-
-/* Handle */
-::-webkit-scrollbar-thumb {
-    background: #333;
-}
-
-/* Handle on hover */
-::-webkit-scrollbar-thumb:hover {
-    background: #555;
-} 
-
-.group {
-
-float: none;
-clear: both;
-margin: 20px 15px 10px 15px;
-border: 2px solid #5f5f5f;
-overflow: auto;
-}
-
-
-.groupmuted {float: none;
-clear: both;
-margin: 20px 15px 10px 15px;
-border: 2px solid #5f5f5f;
-overflow: auto;
-opacity: 0.27;}
-
-.client {
-text-align: center;
-background: rgb(61, 61, 61);
-margin: 10px;
-width: 160px;
-height: 360px;
-float: left;
-}
-
-.disconnected {
-text-align: center;
-background: rgb(61, 61, 61);
-margin: 10px;
-width: 160px;
-height: 360px;
-float: left;
-opacity: 0.27;
-}
-
-
-
-.slider {
-    writing-mode: bt-lr; /* IE */
-    -webkit-appearance: slider-vertical; /* WebKit */
-height: 240px;
-width: 15px;
-}
-
-.slidermute {
-    writing-mode: bt-lr; /* IE */
-    -webkit-appearance: slider-vertical; /* WebKit */
-opacity: 0.27;
-height: 240px;
-width: 15px;
-
-}
-
-.slider_fine {
-    writing-mode: bt-lr; /* IE */
-    -webkit-appearance: slider-vertical; /* WebKit */
-height: 240px;
-width: 15px;
-}
-
-.slidermute_fine {
-    writing-mode: bt-lr; /* IE */
-    -webkit-appearance: slider-vertical; /* WebKit */
-height: 240px;
-width: 15px;
-opacity: 0.27;
-}
-
-
-.sliders {
-text-align: left;
-vertical-align: middle;
-height: 250px;
-padding-top: 10px;
-clear: both;
-float: none;
-
-}
-
-.sliderdiv {
-display: inline-block;
-
-padding-left: 40px;
-text-align: left;
-width: 20px;
-}
-
-.sliderdiv_fine {
-display: inline-block;
-
-text-align: left;
-width: 20px;
-
-position: relative;
-top: 0px;
-left: 13px;
-opacity: 0.01;}
-
-.finebg {
-display: inline-block;
-text-align: center;
-font-size: 35px;
-width: 40px;
-position: relative;
-top: -27px;
-left: 40px;
-color: #999;
-}
-
-select {background-color: rgb(61, 61, 61);
-width: 150px;
-font-size: 20px;
-color: #e3e3e3;
-border: 1px solid #555555;
-    -moz-appearance: none;
-    -webkit-appearance: none;
-    appearancce: none;  
- 
-	}
-	
-	
-.stream {margin-left: 20px;
-width: 200px;
-padding-left:5px;}
-	
-.refreshbutton {background-color: rgb(61, 61, 61);
-
-font-size: 20px;
-color: #e3e3e3;
-border: 1px solid #555555;
-margin-left: 100px;
-	}
-
-.mutebutton {
-color: #e3e3e3;
-font-size: 30px;
-display: block;
-text-decoration: none;
-}
-
-.mutebuttongroup {
-font-size: 30px;
-color: #e3e3e3;
-text-decoration: none;
-}
-
-.edit {color: #e3e3e3;
-text-decoration: none;}
-
-</style>
-    </head>
-
-    <body>
-
-<div id="show"></div>
-    </body>
+<head>
+  <title>Snapcast Interface</title>
+  <script>
+
+    var connection = new WebSocket('ws://volumio-test:2027', 'binary');
+    //var connection = new WebSocket('ws://' + window.location.hostname + ':2027', 'binary');
+
+    connection.binaryType = 'arraybuffer';
+
+    var server;
+
+    connection.onmessage = function (e) {
+      var recv = String.fromCharCode.apply(null, new Uint8Array(e.data));
+      // console.log(recv); 
+      var answer = JSON.parse(recv);
+      if (answer.id == 1) {
+         server = answer.result;
+      } else {
+        // console.log(answer.method);
+        if (Array.isArray(answer)) {
+          for (let i = 0; i < answer.length; i++) {
+            action(answer[i]);
+          }
+        } else {
+          action(answer);
+        }
+      }
+
+      show()
+    }
+
+    connection.onopen = function () {
+      send('{"id":1,"jsonrpc":"2.0","method":"Server.GetStatus"}}\n')
+    }
+
+    connection.onerror = function () {
+      alert("error");
+    }
+
+    function action(answer) {
+      switch (answer.method) {
+        case 'Client.OnVolumeChanged':
+        case 'Client.OnLatencyChanged':
+        case 'Client.OnNameChanged':
+          clientChange(answer.params);
+          break;
+        case 'Client.OnConnect':
+        case 'Client.OnDisconnect':
+          clientConnect(answer.params);
+          break;
+        case 'Group.OnMute':
+          groupMute(answer.params);
+          break;
+        case 'Group.OnStremChanged':
+          groupStream(answer.params);
+          break;
+        case 'Stream.OnUpdate':
+          streamUpdate(answer.params);
+          break;
+        case 'Server.OnUpdate':
+          server = answer.params;
+          break;
+        default:
+          break;
+      }
+    }
+
+    function send(str) {
+      var buf = new ArrayBuffer(str.length);
+      var bufView = new Uint8Array(buf);
+      for (var i = 0, strLen = str.length; i < strLen; i++) {
+        bufView[i] = str.charCodeAt(i);
+      }
+
+      //  console.log(buf);
+      var recv = String.fromCharCode.apply(null, new Uint8Array(buf));
+      //  console.log(recv); 
+
+      connection.send(buf)
+
+    }
+
+    function clientChange(params) {
+      // Update the client configuration with one from params
+      for (let i_group = 0; i_group < server.server.groups.length; i_group++) {
+        for (let i_client = 0; i_client < server.server.groups[i_group].clients.length; i_client++) {
+          if (server.server.groups[i_group].clients[i_client].id == params.id) {
+            server.server.groups[i_group].clients[i_client].config = Object.assign(server.server.groups[i_group].clients[i_client].config, params);
+          }
+        }
+      }
+    }
+
+    function clientConnect(params) {
+      // Update all client info
+      for (let i_group = 0; i_group < server.server.groups.length; i_group++) {
+        for (let i_client = 0; i_client < server.server.groups[i_group].clients.length; i_client++) {
+          if (server.server.groups[i_group].clients[i_client].id == params.client.id) {
+            server.server.groups[i_group].clients[i_client] = params.client;
+            //  console.log(server.server.groups[i_group].clients[i_client]); 
+          }
+        }
+      }
+    }
+
+    function groupMute(params) {
+      // Set group mute boolean
+      for (let i_group = 0; i_group < server.server.groups.length; i_group++) {
+        if (server.server.groups[i_group].id == params.id) {
+          server.server.groups[i_group].muted = params.mute;
+        }
+      }
+    }
+
+    function groupStream(params) {
+      // Set group stream id
+      for (let i_group = 0; i_group < server.server.groups.length; i_group++) {
+        if (server.server.groups[i_group].id == params.id) {
+          server.server.groups[i_group].stream_id = params.stream_id;
+        }
+      }
+    }
+
+    function streamUpdate(params) {
+      // Update all stream inforamtion
+      for (let i_stream = 0; i_stream < server.server.streams.length;) {
+        if (server.server.streams[i_stream].id == params.id) {
+          server.server.streams[i_stream] = params.stream;
+          //  console.log(server.server.streams[i_stream]); 
+        }
+
+      }
+    }
+
+    function show() {
+      // Render the page
+      var content = "";
+
+      for (let i_group = 0; i_group < server.server.groups.length; i_group++) {
+        // Set mute variables
+        var classgroup;
+        var unmuted;
+        var mutetext;
+        if (server.server.groups[i_group].muted == true) {
+          classgroup = 'groupmuted';
+          unmuted = 'false';
+          mutetext = '&#x1F507';
+        } else {
+          classgroup = 'group';
+          unmuted = 'true';
+          mutetext = '&#128266';
+        }
+
+        // Start group div
+        content += "<div id='g_" + server.server.groups[i_group].id + "' class='" + classgroup + "'>";
+
+        // Create stream selection dropdown
+        var streamselect = "<select id='stream_" + server.server.groups[i_group].id + "' onchange='setStream(\"" + server.server.groups[i_group].id + "\")' class='stream'>"
+        for (let i_stream = 0; i_stream < server.server.streams.length; i_stream++) {
+          var streamselected = "";
+          if (server.server.groups[i_group].stream_id == server.server.streams[i_stream].id) {
+            streamselected = 'selected'
+          }
+          streamselect += "<option value='" + server.server.streams[i_stream].id + "' " + streamselected + ">" + server.server.streams[i_stream].id + ": " + server.server.streams[i_stream].status + "</option>";
+        }
+
+        streamselect += "</select>";
+        content += streamselect;
+
+        // Group mute and refresh button
+        content += " <a href=\"javascript:setMuteGroup('" + server.server.groups[i_group].id + "','" + unmuted + "');\" class='mutebuttongroup'>" + mutetext + "</a>";
+        content += "<input type='button' value='Refresh' class='refreshbutton' onclick='javascript: location.reload()'>";
+        content += "<br/>";
+
+        // Create clients in group
+        for (let i_client = 0; i_client < server.server.groups[i_group].clients.length; i_client++) {
+          var sv = server.server.groups[i_group].clients[i_client];
+          
+          // Set name and connection state vars, start client div
+          var name;
+          var clas = 'client'
+          if (sv.config.name != "") {
+            name = sv.config.name;
+          } else {
+            name = sv.host.name;
+          }
+          if (sv.connected == false) {
+            clas = 'disconnected';
+          }
+          content = content + "<div id='c_" + sv.id + "' class='" + clas + "'>";
+
+          // Client mute status vars
+          var unmuted;
+          var mutetextclient;
+          var sliderclass;
+          if (sv.config.volume.muted == true) {
+            unmuted = 'false';
+            sliderclass = 'slidermute';
+            mutetext = '&#128263';
+          } else {
+            sliderclass = 'slider'
+            unmuted = 'true';
+            mutetext = '&#128266';
+          }
+
+          // Client group selection vars
+          var groupselect = "<select id='group_" + sv.id + "' onchange='setGroup(\"" + sv.id + "\")'>";
+          for (let o_group = 0; o_group < server.server.groups.length; o_group++) {
+            var groupselected = "";
+            if (o_group == i_group) {
+              groupselected = 'selected'
+            }
+            groupselect = groupselect + "<option value='" + server.server.groups[o_group].id + "' " + groupselected + ">Group " + o_group + " (" + server.server.groups[o_group].clients.length + " Clients)</option>";
+          }
+
+          groupselect = groupselect + "<option value='new'>new</option>";
+          groupselect = groupselect + "</select>"
+
+          // Populate client div
+          content = content + " <a href=\"javascript:setVolume('" + sv.id + "','" + unmuted + "');\" class='mutebutton'>" + mutetext + "</a>";
+          content = content + "<div class='sliders'><div class='sliderdiv'><input type='range' min=0 max=100 step=1 id='vol_" + sv.id + "' onchange='javascript:setVolume(\"" + sv.id + "\",\"" + sv.config.volume.muted + "\")' value=" + sv.config.volume.percent + " class='" + sliderclass + "' orient='vertical'></div>";
+          content = content + "<div class='finebg'>++<br>+<br>0<br>-<br>--</div><div class='sliderdiv_fine'><input type='range' min=0 max=10 step=1 id='vol_fine_" + sv.id + "' onchange='javascript:setVolume(\"" + sv.id + "\",\"" + sv.config.volume.muted + "\")' value=5 class='" + sliderclass + "_fine' orient='vertical'></div></div>";
+          content = content + " <a href=\"javascript:setName('" + sv.id + "');\" class='edit'>&#9998</a>";
+          content = content + name;
+          content = content + groupselect;
+          content = content + "</div>";
+        }
+
+        content = content + "</div>"
+      }
+
+      // Pad then update page
+      content = content + "<br><br>";
+      document.getElementById('show').innerHTML = content;
+    }
+
+    function setVolume(id, mute) {
+      percent = document.getElementById('vol_' + id).value;
+      percent_fine = document.getElementById('vol_fine_' + id).value;
+      
+      // Take away 5 as it's the default of the fine slider. Only relevant if it
+      // has changed
+      percent = Number(percent) + Number(percent_fine) - 5;
+
+      if (percent < 0) {
+        percent = 0
+      }
+      else if (percent > 100) {
+        percent = 100
+      }
+
+      // Request changes
+      send('{"id":8,"jsonrpc":"2.0","method":"Client.SetVolume","params":{"id":"' + id + '","volume":{"muted":' + mute + ',"percent":' + percent + '}}}')
+
+      // Make updates to server info and refresh content
+      for (let i_group = 0; i_group < server.server.groups.length; i_group++) {
+        for (let i_client = 0; i_client < server.server.groups[i_group].clients.length; i_client++) {
+          var sv = server.server.groups[i_group].clients[i_client];
+          if (sv.id == id) {
+            if (mute == 'true') {
+              sv.config.volume.muted = true;
+            }
+            if (mute == 'false') {
+              sv.config.volume.muted = false;
+            }
+            sv.config.volume.percent = percent;
+          }
+        }
+      }
+      show()
+    }
+
+    function setMuteGroup(id, what) {
+      send('{"id":"MuteGroup_' + id + '","jsonrpc":"2.0","method":"Group.SetMute","params":{"id":"' + id + '","mute":' + what + '}}')
+
+      for (let i_group = 0; i_group < server.server.groups.length; i_group++) {
+        if (server.server.groups[i_group].id == id) {
+          if (what == 'true') {
+            server.server.groups[i_group].muted = true;
+          }
+          if (what == 'false') {
+            server.server.groups[i_group].muted = false;
+          }
+          //  console.log(server.server.groups[i_group]); 
+        }
+      }
+      show()
+    }
+
+    function setStream(id) {
+      send('{"id":4,"jsonrpc":"2.0","method":"Group.SetStream","params":{"id":"' + id + '","stream_id":"' + document.getElementById('stream_' + id).value + '"}}')
+
+      for (let i_group = 0; i_group < server.server.groups.length; i_group++) {
+        if (server.server.groups[i_group].id == id) {
+          server.server.groups[i_group].stream_id = document.getElementById('stream_' + id).value;
+          //  console.log(server.server.groups[i_group]); 
+        }
+      }
+      show()
+    }
+
+    function setGroup(id) {
+      group = document.getElementById('group_' + id).value;
+      
+      // Get client group id
+      var current_group;
+      groups:
+      for (let i_group = 0; i_group < server.server.groups.length; i_group++) {
+        for (let i_client = 0; i_client < server.server.groups[i_group].clients.length; i_client++) {
+          if (id == server.server.groups[i_group].clients[i_client].id) { 
+            current_group = server.server.groups[i_group].id;
+            break groups;
+          }
+        }
+      }
+
+      // Get
+      //   List of target group's clients
+      // OR
+      //   List of current group's other clients
+      var send_clients = [];
+      for (let i_group = 0; i_group < server.server.groups.length; i_group++) {
+        if (server.server.groups[i_group].id == group || (group == "new" && server.server.groups[i_group].id == current_group)) {
+          for (let i_client = 0; i_client < server.server.groups[i_group].clients.length; i_client++) {
+            if (group == "new" && server.server.groups[i_group].clients[i_client].id == id) { }
+            else {
+              send_clients[send_clients.length] = server.server.groups[i_group].clients[i_client].id;
+            }
+          }
+        }
+      }
+
+      if (group == "new") {
+        group = current_group
+      }
+      else { 
+        send_clients[send_clients.length] = id;
+      }
+
+      var send_clients_string = JSON.stringify(send_clients);
+      send('{"id":1,"jsonrpc":"2.0","method":"Group.SetClients","params":{"clients":' + send_clients_string + ',"id":"' + group + '"}}')
+    }
+
+    function setName(id) {
+      // Get current name and lacency
+      var current_name;
+      var current_latency;
+      groups:
+      for (let i_group = 0; i_group < server.server.groups.length; i_group++) {
+        for (let i_client = 0; i_client < server.server.groups[i_group].clients.length; i_client++) {
+          var sv = server.server.groups[i_group].clients[i_client];
+          if (sv.id == id) {
+            if (sv.config.name != "") {
+              current_name = sv.config.name;
+            } else {
+              current_name = sv.host.name;
+            }
+            current_latency = sv.config.latency;
+            break groups;
+          }
+        }
+      }
+      
+      var newName = window.prompt("New Name", current_name);
+      var newLatency = window.prompt("New Latency", current_latency);
+
+      // Don't change anything if user cancel's
+      if (newName != null) {
+        send('{"id":6,"jsonrpc":"2.0","method":"Client.SetName","params":{"id":"' + id + '","name":"' + newName + '"}}')
+      } else {
+        newName = current_name
+      }
+      if (newLatency != null) {
+        send('{"id":7,"jsonrpc":"2.0","method":"Client.SetLatency","params":{"id":"' + id + '","latency":' + newLatency + '}}')
+      } else {
+        newLatency = current_latency
+      }
+
+      for (let i_group = 0; i_group < server.server.groups.length; i_group++) {
+        for (let i_client = 0; i_client < server.server.groups[i_group].clients.length; i_client++) {
+          var sv = server.server.groups[i_group].clients[i_client];
+          if (sv.id == id) {
+            sv.config.name = newName;
+            sv.config.latency = newLatency;
+          }
+        }
+      }
+      show()
+    }
+
+  </script>
+  <style>
+    body {
+      background: #1f1f1f;
+      color: rgb(255, 255, 255);
+      font-family: 'Arial', sans-serif;
+      width: 100%;
+      margin: 0;
+      font-size: 20px;
+    }
+
+    /* width */
+    ::-webkit-scrollbar {
+      width: 10px;
+    }
+
+    /* Track */
+    ::-webkit-scrollbar-track {
+      background: #1f1f1f;
+    }
+
+    /* Handle */
+    ::-webkit-scrollbar-thumb {
+      background: #333;
+    }
+
+    /* Handle on hover */
+    ::-webkit-scrollbar-thumb:hover {
+      background: #555;
+    }
+
+    .group {
+      float: none;
+      clear: both;
+      margin: 20px 15px 10px 15px;
+      border: 2px solid #5f5f5f;
+      overflow: auto;
+    }
+
+    .groupmuted {
+      float: none;
+      clear: both;
+      margin: 20px 15px 10px 15px;
+      border: 2px solid #5f5f5f;
+      overflow: auto;
+      opacity: 0.27;
+    }
+
+    .client {
+      text-align: center;
+      background: rgb(61, 61, 61);
+      margin: 10px;
+      width: 160px;
+      height: 360px;
+      float: left;
+    }
+
+    .disconnected {
+      text-align: center;
+      background: rgb(61, 61, 61);
+      margin: 10px;
+      width: 160px;
+      height: 360px;
+      float: left;
+      opacity: 0.27;
+    }
+
+    .slider {
+      writing-mode: bt-lr;
+      /* IE */
+      -webkit-appearance: slider-vertical;
+      /* WebKit */
+      height: 240px;
+      width: 15px;
+    }
+
+    .slidermute {
+      writing-mode: bt-lr;
+      /* IE */
+      -webkit-appearance: slider-vertical;
+      /* WebKit */
+      opacity: 0.27;
+      height: 240px;
+      width: 15px;
+    }
+
+    .slider_fine {
+      writing-mode: bt-lr;
+      /* IE */
+      -webkit-appearance: slider-vertical;
+      /* WebKit */
+      height: 240px;
+      width: 15px;
+    }
+
+    .slidermute_fine {
+      writing-mode: bt-lr;
+      /* IE */
+      -webkit-appearance: slider-vertical;
+      /* WebKit */
+      height: 240px;
+      width: 15px;
+      opacity: 0.27;
+    }
+
+    .sliders {
+      text-align: left;
+      vertical-align: middle;
+      height: 250px;
+      padding-top: 10px;
+      clear: both;
+      float: none;
+    }
+
+    .sliderdiv {
+      display: inline-block;
+      padding-left: 40px;
+      text-align: left;
+      width: 20px;
+    }
+
+    .sliderdiv_fine {
+      display: inline-block;
+      text-align: left;
+      width: 20px;
+      position: relative;
+      top: 0px;
+      left: 13px;
+      opacity: 0.01;
+    }
+
+    .finebg {
+      display: inline-block;
+      text-align: center;
+      font-size: 35px;
+      width: 40px;
+      position: relative;
+      top: -27px;
+      left: 40px;
+      color: #999;
+    }
+
+    select {
+      background-color: rgb(61, 61, 61);
+      width: 150px;
+      font-size: 20px;
+      color: #e3e3e3;
+      border: 1px solid #555555;
+      -moz-appearance: none;
+      -webkit-appearance: none;
+      appearance: none;
+    }
+
+    .stream {
+      margin-left: 20px;
+      width: 200px;
+      padding-left: 5px;
+    }
+
+    .refreshbutton {
+      background-color: rgb(61, 61, 61);
+      font-size: 20px;
+      color: #e3e3e3;
+      border: 1px solid #555555;
+      margin-left: 100px;
+    }
+
+    .mutebutton {
+      color: #e3e3e3;
+      font-size: 30px;
+      display: block;
+      text-decoration: none;
+    }
+
+    .mutebuttongroup {
+      font-size: 30px;
+      color: #e3e3e3;
+      text-decoration: none;
+    }
+
+    .edit {
+      color: #e3e3e3;
+      text-decoration: none;
+    }
+  </style>
+</head>
+
+<body>
+  <div id="show"></div>
+</body>
 
 </html>
-

--- a/interface.html
+++ b/interface.html
@@ -4,7 +4,7 @@
   <title>Snapcast Interface</title>
   <script>
 
-    var connection = new WebSocket('ws://volumio-test:2027', 'binary');
+    var connection = new WebSocket('ws://volumio-test:1780', 'binary');
     //var connection = new WebSocket('ws://' + window.location.hostname + ':2027', 'binary');
 
     connection.binaryType = 'arraybuffer';
@@ -15,6 +15,7 @@
       var recv = String.fromCharCode.apply(null, new Uint8Array(e.data));
       // console.log(recv); 
       var answer = JSON.parse(recv);
+      console.log(answer)
       if (answer.id == 1) {
          server = answer.result;
       } else if (Array.isArray(answer)) {
@@ -250,7 +251,7 @@
       }
 
       // Request changes
-      send('{"id":8,"jsonrpc":"2.0","method":"Client.SetVolume","params":{"id":"' + id + '","volume":{"muted":' + mute + ',"percent":' + percent + '}}}')
+      send('{"id":8,"jsonrpc":"2.0","method":"Client.SetVolume","params":{"id":"' + id + '","volume":{"muted":' + mute + ',"percent":' + percent + '}}}}\n')
 
       // Make updates to server info and refresh content
       for (let i_group = 0; i_group < server.server.groups.length; i_group++) {
@@ -271,7 +272,7 @@
     }
 
     function setMuteGroup(id, what) {
-      send('{"id":"MuteGroup_' + id + '","jsonrpc":"2.0","method":"Group.SetMute","params":{"id":"' + id + '","mute":' + what + '}}')
+      send('{"id":"MuteGroup_' + id + '","jsonrpc":"2.0","method":"Group.SetMute","params":{"id":"' + id + '","mute":' + what + '}}}\n')
 
       for (let i_group = 0; i_group < server.server.groups.length; i_group++) {
         if (server.server.groups[i_group].id == id) {
@@ -288,7 +289,7 @@
     }
 
     function setStream(id) {
-      send('{"id":4,"jsonrpc":"2.0","method":"Group.SetStream","params":{"id":"' + id + '","stream_id":"' + document.getElementById('stream_' + id).value + '"}}')
+      send('{"id":4,"jsonrpc":"2.0","method":"Group.SetStream","params":{"id":"' + id + '","stream_id":"' + document.getElementById('stream_' + id).value + '"}}}\n')
 
       for (let i_group = 0; i_group < server.server.groups.length; i_group++) {
         if (server.server.groups[i_group].id == id) {
@@ -338,7 +339,7 @@
       }
 
       var send_clients_string = JSON.stringify(send_clients);
-      send('{"id":1,"jsonrpc":"2.0","method":"Group.SetClients","params":{"clients":' + send_clients_string + ',"id":"' + group + '"}}')
+      send('{"id":1,"jsonrpc":"2.0","method":"Group.SetClients","params":{"clients":' + send_clients_string + ',"id":"' + group + '"}}}\n')
     }
 
     function setName(id) {
@@ -366,12 +367,12 @@
 
       // Don't change anything if user cancel's
       if (newName != null) {
-        send('{"id":6,"jsonrpc":"2.0","method":"Client.SetName","params":{"id":"' + id + '","name":"' + newName + '"}}')
+        send('{"id":6,"jsonrpc":"2.0","method":"Client.SetName","params":{"id":"' + id + '","name":"' + newName + '"}}}\n')
       } else {
         newName = current_name
       }
       if (newLatency != null) {
-        send('{"id":7,"jsonrpc":"2.0","method":"Client.SetLatency","params":{"id":"' + id + '","latency":' + newLatency + '}}')
+        send('{"id":7,"jsonrpc":"2.0","method":"Client.SetLatency","params":{"id":"' + id + '","latency":' + newLatency + '}}}\n')
       } else {
         newLatency = current_latency
       }


### PR DESCRIPTION
Allow support of JSON RCP requests by looking at response type. Allow user to cancel name/latency changes (note can't set name to none as a consequence).

 Update syntax (for readability) and comment code. Actual functionality changes only in `connection.oncmessage`, `action` and `setName` functions: the rest of the changes are purely syntax and comments. More notes on this on the comment on the 1st commit

Fixes #3 